### PR TITLE
複数行コメント/**/でコメント表示の追加

### DIFF
--- a/syntaxes/aiscript.tmLanguage.json
+++ b/syntaxes/aiscript.tmLanguage.json
@@ -27,7 +27,22 @@
                 {
                     "name": "comment.line.aiscript",
                     "match": "\\/\\/.*"
-                }
+                },
+				{
+					"name": "comment.block.aiscript",
+					"begin": "/\\*",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.comment.aiscript"
+						}
+					},
+					"end": "\\*/",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.comment.aiscript"
+						}
+					}
+				}
             ]
         },
 		"script_configuration": {


### PR DESCRIPTION
/**/での複数行コメント(#2)を追加しました。

[beginCaptures](https://github.com/70165tk/aiscript-syntax-vscode/blob/296049882fa295a36e4c02b835573a993ff3ec81/syntaxes/aiscript.tmLanguage.json#L34-L38)と[endCaptures](https://github.com/70165tk/aiscript-syntax-vscode/blob/296049882fa295a36e4c02b835573a993ff3ec81/syntaxes/aiscript.tmLanguage.json#L40-L44)の内容は[他言語での拡張](https://github.com/microsoft/vscode/blob/d9faba4a97c8afa56948a7bd5b4fba028116988e/extensions/csharp/syntaxes/csharp.tmLanguage.json#L4761-L4775)で用いられている形式に倣ったもので、
無くても同様に動作するので、必要に応じて変更・削除できます。